### PR TITLE
Add resume and site info

### DIFF
--- a/2024/07/27/hello-world/index.html
+++ b/2024/07/27/hello-world/index.html
@@ -4,18 +4,18 @@
   <meta charset="utf-8">
   
   
-  <title>Hello World | Hexo</title>
+  <title>Hello World | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="Welcome to Hexo! This is your very first post. Check documentation for more info. If you get any problems when using Hexo, you can find the answer in troubleshooting or you can ask me on GitHub. Quick">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Hello World">
 <meta property="og:url" content="http://example.com/2024/07/27/hello-world/index.html">
-<meta property="og:site_name" content="Hexo">
+<meta property="og:site_name" content="Xinjie Zhang">
 <meta property="og:description" content="Welcome to Hexo! This is your very first post. Check documentation for more info. If you get any problems when using Hexo, you can find the answer in troubleshooting or you can ask me on GitHub. Quick">
 <meta property="og:locale" content="en_US">
 <meta property="article:published_time" content="2024-07-27T12:35:44.918Z">
 <meta property="article:modified_time" content="2024-07-27T12:35:44.920Z">
-<meta property="article:author" content="John Doe">
+<meta property="article:author" content="Xinjie Zhang">
 <meta name="twitter:card" content="summary">
   
     <link rel="alternate" href="/atom.xml" title="Hexo" type="application/atom+xml">
@@ -43,7 +43,7 @@
   <div id="header-outer" class="outer">
     <div id="header-title" class="inner">
       <h1 id="logo-wrap">
-        <a href="/" id="logo">Hexo</a>
+        <a href="/" id="logo">Xinjie Zhang</a>
       </h1>
       
     </div>
@@ -54,6 +54,7 @@
           <a class="main-nav-link" href="/">Home</a>
         
           <a class="main-nav-link" href="/archives">Archives</a>
+          <a class="main-nav-link" href="/resume/">Resume</a>
         
       </nav>
       <nav id="sub-nav">
@@ -185,7 +186,7 @@
   <div class="outer">
     <div id="footer-info" class="inner">
       
-      &copy; 2024 John Doe<br>
+      &copy; 2024 Xinjie Zhang<br>
       Powered by <a href="https://hexo.io/" target="_blank">Hexo</a>
     </div>
   </div>
@@ -197,6 +198,7 @@
     <a href="/" class="mobile-nav-link">Home</a>
   
     <a href="/archives" class="mobile-nav-link">Archives</a>
+    <a href="/resume/" class="mobile-nav-link">Resume</a>
   
 </nav>
     

--- a/2024/07/27/my-first-page/index.html
+++ b/2024/07/27/my-first-page/index.html
@@ -4,16 +4,16 @@
   <meta charset="utf-8">
   
   
-  <title>my first page | Hexo</title>
+  <title>my first page | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta property="og:type" content="article">
 <meta property="og:title" content="my first page">
 <meta property="og:url" content="http://example.com/2024/07/27/my-first-page/index.html">
-<meta property="og:site_name" content="Hexo">
+<meta property="og:site_name" content="Xinjie Zhang">
 <meta property="og:locale" content="en_US">
 <meta property="article:published_time" content="2024-07-27T13:04:53.000Z">
 <meta property="article:modified_time" content="2024-07-27T13:04:53.082Z">
-<meta property="article:author" content="John Doe">
+<meta property="article:author" content="Xinjie Zhang">
 <meta name="twitter:card" content="summary">
   
     <link rel="alternate" href="/atom.xml" title="Hexo" type="application/atom+xml">
@@ -41,7 +41,7 @@
   <div id="header-outer" class="outer">
     <div id="header-title" class="inner">
       <h1 id="logo-wrap">
-        <a href="/" id="logo">Hexo</a>
+        <a href="/" id="logo">Xinjie Zhang</a>
       </h1>
       
     </div>
@@ -52,6 +52,7 @@
           <a class="main-nav-link" href="/">Home</a>
         
           <a class="main-nav-link" href="/archives">Archives</a>
+          <a class="main-nav-link" href="/resume/">Resume</a>
         
       </nav>
       <nav id="sub-nav">
@@ -166,7 +167,7 @@
   <div class="outer">
     <div id="footer-info" class="inner">
       
-      &copy; 2024 John Doe<br>
+      &copy; 2024 Xinjie Zhang<br>
       Powered by <a href="https://hexo.io/" target="_blank">Hexo</a>
     </div>
   </div>
@@ -178,6 +179,7 @@
     <a href="/" class="mobile-nav-link">Home</a>
   
     <a href="/archives" class="mobile-nav-link">Archives</a>
+    <a href="/resume/" class="mobile-nav-link">Resume</a>
   
 </nav>
     

--- a/archives/2024/07/index.html
+++ b/archives/2024/07/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   
   
-  <title>Archives: 2024/7 | Hexo</title>
+  <title>Archives: 2024/7 | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta property="og:type" content="website">
-<meta property="og:title" content="Hexo">
+<meta property="og:title" content="Xinjie Zhang">
 <meta property="og:url" content="http://example.com/archives/2024/07/index.html">
-<meta property="og:site_name" content="Hexo">
+<meta property="og:site_name" content="Xinjie Zhang">
 <meta property="og:locale" content="en_US">
-<meta property="article:author" content="John Doe">
+<meta property="article:author" content="Xinjie Zhang">
 <meta name="twitter:card" content="summary">
   
     <link rel="alternate" href="/atom.xml" title="Hexo" type="application/atom+xml">
@@ -39,7 +39,7 @@
   <div id="header-outer" class="outer">
     <div id="header-title" class="inner">
       <h1 id="logo-wrap">
-        <a href="/" id="logo">Hexo</a>
+        <a href="/" id="logo">Xinjie Zhang</a>
       </h1>
       
     </div>
@@ -50,6 +50,7 @@
           <a class="main-nav-link" href="/">Home</a>
         
           <a class="main-nav-link" href="/archives">Archives</a>
+          <a class="main-nav-link" href="/resume/">Resume</a>
         
       </nav>
       <nav id="sub-nav">
@@ -170,7 +171,7 @@
   <div class="outer">
     <div id="footer-info" class="inner">
       
-      &copy; 2024 John Doe<br>
+      &copy; 2024 Xinjie Zhang<br>
       Powered by <a href="https://hexo.io/" target="_blank">Hexo</a>
     </div>
   </div>
@@ -182,6 +183,7 @@
     <a href="/" class="mobile-nav-link">Home</a>
   
     <a href="/archives" class="mobile-nav-link">Archives</a>
+    <a href="/resume/" class="mobile-nav-link">Resume</a>
   
 </nav>
     

--- a/archives/index.html
+++ b/archives/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   
   
-  <title>Archives | Hexo</title>
+  <title>Archives | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta property="og:type" content="website">
-<meta property="og:title" content="Hexo">
+<meta property="og:title" content="Xinjie Zhang">
 <meta property="og:url" content="http://example.com/archives/index.html">
-<meta property="og:site_name" content="Hexo">
+<meta property="og:site_name" content="Xinjie Zhang">
 <meta property="og:locale" content="en_US">
-<meta property="article:author" content="John Doe">
+<meta property="article:author" content="Xinjie Zhang">
 <meta name="twitter:card" content="summary">
   
     <link rel="alternate" href="/atom.xml" title="Hexo" type="application/atom+xml">
@@ -39,7 +39,7 @@
   <div id="header-outer" class="outer">
     <div id="header-title" class="inner">
       <h1 id="logo-wrap">
-        <a href="/" id="logo">Hexo</a>
+        <a href="/" id="logo">Xinjie Zhang</a>
       </h1>
       
     </div>
@@ -50,6 +50,7 @@
           <a class="main-nav-link" href="/">Home</a>
         
           <a class="main-nav-link" href="/archives">Archives</a>
+          <a class="main-nav-link" href="/resume/">Resume</a>
         
       </nav>
       <nav id="sub-nav">
@@ -170,7 +171,7 @@
   <div class="outer">
     <div id="footer-info" class="inner">
       
-      &copy; 2024 John Doe<br>
+      &copy; 2024 Xinjie Zhang<br>
       Powered by <a href="https://hexo.io/" target="_blank">Hexo</a>
     </div>
   </div>
@@ -182,6 +183,7 @@
     <a href="/" class="mobile-nav-link">Home</a>
   
     <a href="/archives" class="mobile-nav-link">Archives</a>
+    <a href="/resume/" class="mobile-nav-link">Resume</a>
   
 </nav>
     

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   
   
-  <title>Hexo</title>
+  <title>Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta property="og:type" content="website">
-<meta property="og:title" content="Hexo">
+<meta property="og:title" content="Xinjie Zhang">
 <meta property="og:url" content="http://example.com/index.html">
-<meta property="og:site_name" content="Hexo">
+<meta property="og:site_name" content="Xinjie Zhang">
 <meta property="og:locale" content="en_US">
-<meta property="article:author" content="John Doe">
+<meta property="article:author" content="Xinjie Zhang">
 <meta name="twitter:card" content="summary">
   
     <link rel="alternate" href="/atom.xml" title="Hexo" type="application/atom+xml">
@@ -39,7 +39,7 @@
   <div id="header-outer" class="outer">
     <div id="header-title" class="inner">
       <h1 id="logo-wrap">
-        <a href="/" id="logo">Hexo</a>
+        <a href="/" id="logo">Xinjie Zhang</a>
       </h1>
       
     </div>
@@ -50,6 +50,7 @@
           <a class="main-nav-link" href="/">Home</a>
         
           <a class="main-nav-link" href="/archives">Archives</a>
+          <a class="main-nav-link" href="/resume/">Resume</a>
         
       </nav>
       <nav id="sub-nav">
@@ -209,7 +210,7 @@
   <div class="outer">
     <div id="footer-info" class="inner">
       
-      &copy; 2024 John Doe<br>
+      &copy; 2024 Xinjie Zhang<br>
       Powered by <a href="https://hexo.io/" target="_blank">Hexo</a>
     </div>
   </div>
@@ -221,6 +222,7 @@
     <a href="/" class="mobile-nav-link">Home</a>
   
     <a href="/archives" class="mobile-nav-link">Archives</a>
+    <a href="/resume/" class="mobile-nav-link">Resume</a>
   
 </nav>
     

--- a/resume/index.html
+++ b/resume/index.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   
   
-  <title>Archives: 2024 | Xinjie Zhang</title>
+  <title>Resume | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta property="og:type" content="website">
-<meta property="og:title" content="Xinjie Zhang">
-<meta property="og:url" content="http://example.com/archives/2024/index.html">
+  <meta property="og:type" content="article">
+<meta property="og:title" content="Resume">
+<meta property="og:url" content="http://example.com/resume/index.html">
 <meta property="og:site_name" content="Xinjie Zhang">
 <meta property="og:locale" content="en_US">
 <meta property="article:author" content="Xinjie Zhang">
@@ -68,102 +68,62 @@
 </header>
 
       <div class="outer">
-        <section id="main">
-  
-  
+        <section id="main"><article id="post-resume" class="h-entry article article-type-post" itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
+  <div class="article-inner">
     
     
-      
-      
-      <section class="archives-wrap">
-        <div class="archive-year-wrap">
-          <a href="/archives/2024" class="archive-year">2024</a>
-        </div>
-        <div class="archives">
-    
-    <article class="archive-article archive-type-post">
-  <div class="archive-article-inner">
-    <header class="archive-article-header">
-      <a href="/2024/07/27/my-first-page/" class="archive-article-date">
-  <time class="dt-published" datetime="2024-07-27T13:04:53.000Z" itemprop="datePublished">Jul 27</time>
-</a>
-      
+      <header class="article-header">
+        
   
-    <h1 itemprop="name">
-      <a class="archive-article-title" href="/2024/07/27/my-first-page/">my first page</a>
+    <h1 class="p-name article-title" itemprop="headline name">
+      Resume
     </h1>
   
 
-    </header>
-  </div>
-</article>
-  
+      </header>
     
-    
-    <article class="archive-article archive-type-post">
-  <div class="archive-article-inner">
-    <header class="archive-article-header">
-      <a href="/2024/07/27/hello-world/" class="archive-article-date">
-  <time class="dt-published" datetime="2024-07-27T12:35:44.918Z" itemprop="datePublished">Jul 27</time>
-</a>
+    <div class="e-content article-entry" itemprop="articleBody">
+<h2>Contact</h2>
+<ul>
+  <li>Location: New York, USA</li>
+  <li>Email: <a href="mailto:xinjie.zhang@columbia.edu">xinjie.zhang@columbia.edu</a></li>
+  <li>Phone: +1&nbsp;551&nbsp;482&nbsp;6812</li>
+</ul>
+<h2>Education</h2>
+<ul>
+  <li><strong>Columbia University</strong>, BA in Applied Mathematics and BA in Computer Science (Sep&nbsp;2024&nbsp;&ndash;&nbsp;May&nbsp;2026, CGPA 4.066/4.33). Dean&rsquo;s List.</li>
+  <li><strong>City University of Hong Kong</strong>, BSc in Computer Science, Minor in Mathematics (Sep&nbsp;2021&nbsp;&ndash;&nbsp;Jun&nbsp;2026, CGPA 3.97/4.3). Talents Program, Dean&rsquo;s List, Dr&nbsp;Herman Hu Scholarship.</li>
+  <li><strong>Peking University</strong>, Globex Summer Program (Jun&nbsp;&ndash;&nbsp;Jul&nbsp;2023).</li>
+</ul>
+<h2>Research Experience</h2>
+<ul>
+  <li>Research Assistant, Shenzhen Research Institute, CityU (Aug&nbsp;2023&nbsp;&ndash;&nbsp;May&nbsp;2024). Built a reinforcement-learning-based scheduler for real-time multi-model inference on edge GPUs.</li>
+</ul>
+<h2>Academic Experience</h2>
+<ul>
+  <li>Student Helper, CS2204 &ndash; Fundamentals of Internet Applications Development, CityU (Jun&nbsp;&ndash;&nbsp;Aug&nbsp;2023).</li>
+  <li>ICPC Team Leader (Oct&nbsp;2022&nbsp;&ndash;&nbsp;Nov&nbsp;2023), earned Honorable Mention.</li>
+</ul>
+<h2>Skills</h2>
+<ul>
+  <li>Languages &amp; Frameworks: C/C++, Java, Python (PyTorch, Transformers, etc.), HTML/CSS/JavaScript/TypeScript, Bash.</li>
+  <li>Tools: Git, Linux command line, CUDA-enabled GPUs.</li>
+  <li>Languages: English (Fluent), Mandarin and Shanghainese (Native).</li>
+</ul>
       
-  
-    <h1 itemprop="name">
-      <a class="archive-article-title" href="/2024/07/27/hello-world/">Hello World</a>
-    </h1>
-  
-
-    </header>
+        
+      
+    </div>
   </div>
+  
+    
+
+  
 </article>
-  
-  
-    </div></section>
-  
 
 
 </section>
         
-          <aside id="sidebar">
-  
-    
-
-  
-    
-
-  
-    
-  
-    
-  <div class="widget-wrap">
-    <h3 class="widget-title">Archives</h3>
-    <div class="widget">
-      <ul class="archive-list"><li class="archive-list-item"><a class="archive-list-link" href="/archives/2024/07/">July 2024</a></li></ul>
-    </div>
-  </div>
-
-
-  
-    
-  <div class="widget-wrap">
-    <h3 class="widget-title">Recent Posts</h3>
-    <div class="widget">
-      <ul>
-        
-          <li>
-            <a href="/2024/07/27/my-first-page/">my first page</a>
-          </li>
-        
-          <li>
-            <a href="/2024/07/27/hello-world/">Hello World</a>
-          </li>
-        
-      </ul>
-    </div>
-  </div>
-
-  
-</aside>
         
       </div>
       <footer id="footer">


### PR DESCRIPTION
## Summary
- add a new resume page containing contact, education, experience and skills
- link to the resume page from site navigation and mobile navigation
- update the author name and site title to "Xinjie Zhang" across pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841002e4b24832eb3fe0b0a95018001