### PR TITLE
Create personal website subpages

### DIFF
--- a/academic-experience/index.html
+++ b/academic-experience/index.html
@@ -2,9 +2,8 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Xinjie Zhang</title>
+  <title>Academic Experience | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="Personal website of Xinjie Zhang">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/fancybox/jquery.fancybox.min.css">
 </head>
@@ -31,24 +30,25 @@
           </div>
         </div>
       </header>
-
       <div class="outer">
         <section id="main">
           <article class="h-entry">
             <div class="article-inner">
               <header class="article-header">
-                <h1 class="p-name article-title">About Me</h1>
+                <h1 class="p-name article-title">Academic Experience</h1>
               </header>
               <div class="e-content article-entry">
-                <p>I am enrolled in the Joint Bachelor&rsquo;s Degree Program between Columbia University and the City University of Hong Kong. At Columbia I study Applied Mathematics and Computer Science, while at CityU I pursue the artificial intelligence stream with a minor in Mathematics. My coursework spans advanced programming, natural language processing, deep learning for computer vision and stochastic analysis.</p>
-                <p>My research centers on sample&ndash;efficient reinforcement learning and efficient deep learning for edge AI. At Rensselaer Polytechnic Institute I work on dataset filtering for in&ndash;context RL. Previously I built a reinforcement&ndash;learning scheduler for multi&ndash;model inference on edge GPUs at the Shenzhen Research Institute, CityU.</p>
-                <p>I lead a team in the International Collegiate Programming Contest and contribute to web development projects. For a complete overview of my background and current work, explore the Publications, Research Experience, Academic Experience and Awards pages.</p>
+                <ul>
+                  <li><strong>Student Helper</strong>, CS2204 &ndash; Fundamentals of Internet Applications Development, CityU (Jun&nbsp;–&nbsp;Aug&nbsp;2023). Assisted with project preparation and grading.</li>
+                  <li><strong>International Collegiate Programming Contest</strong> Team Leader (Oct&nbsp;2022&nbsp;–&nbsp;Nov&nbsp;2023). Earned an Honorable Mention.</li>
+                  <li><strong>Box2D Lunar Lander Optimal Control</strong> &ndash; CS4486 Artificial Intelligence Course Project (Apr&nbsp;–&nbsp;May&nbsp;2023). Developed a Double DQN agent for precise landings.</li>
+                  <li><strong>Glass Surface Detection</strong> &ndash; COMS4995W Topics in Computer Science (Sep&nbsp;–&nbsp;Dec&nbsp;2024). Co-designed GlassMindNet for transparent-glass segmentation.</li>
+                </ul>
               </div>
             </div>
           </article>
         </section>
       </div>
-
       <footer id="footer">
         <div class="outer">
           <div id="footer-info" class="inner">

--- a/awards/index.html
+++ b/awards/index.html
@@ -2,9 +2,8 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Xinjie Zhang</title>
+  <title>Awards | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="Personal website of Xinjie Zhang">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/fancybox/jquery.fancybox.min.css">
 </head>
@@ -31,24 +30,26 @@
           </div>
         </div>
       </header>
-
       <div class="outer">
         <section id="main">
           <article class="h-entry">
             <div class="article-inner">
               <header class="article-header">
-                <h1 class="p-name article-title">About Me</h1>
+                <h1 class="p-name article-title">Awards</h1>
               </header>
               <div class="e-content article-entry">
-                <p>I am enrolled in the Joint Bachelor&rsquo;s Degree Program between Columbia University and the City University of Hong Kong. At Columbia I study Applied Mathematics and Computer Science, while at CityU I pursue the artificial intelligence stream with a minor in Mathematics. My coursework spans advanced programming, natural language processing, deep learning for computer vision and stochastic analysis.</p>
-                <p>My research centers on sample&ndash;efficient reinforcement learning and efficient deep learning for edge AI. At Rensselaer Polytechnic Institute I work on dataset filtering for in&ndash;context RL. Previously I built a reinforcement&ndash;learning scheduler for multi&ndash;model inference on edge GPUs at the Shenzhen Research Institute, CityU.</p>
-                <p>I lead a team in the International Collegiate Programming Contest and contribute to web development projects. For a complete overview of my background and current work, explore the Publications, Research Experience, Academic Experience and Awards pages.</p>
+                <ul>
+                  <li>Dean&rsquo;s List, Columbia University</li>
+                  <li>Dr&nbsp;Herman Hu Scholarships for Joint Degree Programmes, CityU</li>
+                  <li>Talents Program (Top 10% of students), CityU</li>
+                  <li>Dean&rsquo;s List, CityU</li>
+                  <li>Honorable Mention, International Collegiate Programming Contest</li>
+                </ul>
               </div>
             </div>
           </article>
         </section>
       </div>
-
       <footer id="footer">
         <div class="outer">
           <div id="footer-info" class="inner">

--- a/publications/index.html
+++ b/publications/index.html
@@ -2,9 +2,8 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Xinjie Zhang</title>
+  <title>Publications | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="Personal website of Xinjie Zhang">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/fancybox/jquery.fancybox.min.css">
 </head>
@@ -31,24 +30,24 @@
           </div>
         </div>
       </header>
-
       <div class="outer">
         <section id="main">
           <article class="h-entry">
             <div class="article-inner">
               <header class="article-header">
-                <h1 class="p-name article-title">About Me</h1>
+                <h1 class="p-name article-title">Publications</h1>
               </header>
               <div class="e-content article-entry">
-                <p>I am enrolled in the Joint Bachelor&rsquo;s Degree Program between Columbia University and the City University of Hong Kong. At Columbia I study Applied Mathematics and Computer Science, while at CityU I pursue the artificial intelligence stream with a minor in Mathematics. My coursework spans advanced programming, natural language processing, deep learning for computer vision and stochastic analysis.</p>
-                <p>My research centers on sample&ndash;efficient reinforcement learning and efficient deep learning for edge AI. At Rensselaer Polytechnic Institute I work on dataset filtering for in&ndash;context RL. Previously I built a reinforcement&ndash;learning scheduler for multi&ndash;model inference on edge GPUs at the Shenzhen Research Institute, CityU.</p>
-                <p>I lead a team in the International Collegiate Programming Contest and contribute to web development projects. For a complete overview of my background and current work, explore the Publications, Research Experience, Academic Experience and Awards pages.</p>
+                <ul>
+                  <li>Weiqin Chen, <strong>Xinjie Zhang</strong>, Dharmashankar Subramanian, and Santiago Paternain.<br>
+                  "<a href="https://arxiv.org/abs/2505.15143"><em>Filtering Learning Histories Enhances In-Context Reinforcement Learning</em></a>."<br>
+                  <em>arXiv preprint arXiv:2505.15143</em>, 2025.</li>
+                </ul>
               </div>
             </div>
           </article>
         </section>
       </div>
-
       <footer id="footer">
         <div class="outer">
           <div id="footer-info" class="inner">

--- a/research-experience/index.html
+++ b/research-experience/index.html
@@ -2,9 +2,8 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Xinjie Zhang</title>
+  <title>Research Experience | Xinjie Zhang</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="Personal website of Xinjie Zhang">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/fancybox/jquery.fancybox.min.css">
 </head>
@@ -31,24 +30,23 @@
           </div>
         </div>
       </header>
-
       <div class="outer">
         <section id="main">
           <article class="h-entry">
             <div class="article-inner">
               <header class="article-header">
-                <h1 class="p-name article-title">About Me</h1>
+                <h1 class="p-name article-title">Research Experience</h1>
               </header>
               <div class="e-content article-entry">
-                <p>I am enrolled in the Joint Bachelor&rsquo;s Degree Program between Columbia University and the City University of Hong Kong. At Columbia I study Applied Mathematics and Computer Science, while at CityU I pursue the artificial intelligence stream with a minor in Mathematics. My coursework spans advanced programming, natural language processing, deep learning for computer vision and stochastic analysis.</p>
-                <p>My research centers on sample&ndash;efficient reinforcement learning and efficient deep learning for edge AI. At Rensselaer Polytechnic Institute I work on dataset filtering for in&ndash;context RL. Previously I built a reinforcement&ndash;learning scheduler for multi&ndash;model inference on edge GPUs at the Shenzhen Research Institute, CityU.</p>
-                <p>I lead a team in the International Collegiate Programming Contest and contribute to web development projects. For a complete overview of my background and current work, explore the Publications, Research Experience, Academic Experience and Awards pages.</p>
+                <ul>
+                  <li><strong>Research Assistant</strong>, Shenzhen Research Institute, CityU (Aug&nbsp;2023&nbsp;&ndash;&nbsp;May&nbsp;2024). Built a reinforcement-learning-based scheduler that orchestrates CUDA streams and pruned models for efficient edge inference.</li>
+                  <li><strong>Remote Research Assistant</strong>, Rensselaer Polytechnic Institute (Mar&nbsp;2025&nbsp;&ndash;&nbsp;Present). Developing dataset filtering methods for in-context reinforcement learning.</li>
+                </ul>
               </div>
             </div>
           </article>
         </section>
       </div>
-
       <footer id="footer">
         <div class="outer">
           <div id="footer-info" class="inner">

--- a/resume/index.html
+++ b/resume/index.html
@@ -46,11 +46,11 @@
     <div id="header-inner" class="inner">
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
-        
-          <a class="main-nav-link" href="/">Home</a>
-        
-          <a class="main-nav-link" href="/resume/">Resume</a>
-        
+        <a class="main-nav-link" href="/">Home</a>
+        <a class="main-nav-link" href="/publications/">Publications</a>
+        <a class="main-nav-link" href="/research-experience/">Research Experience</a>
+        <a class="main-nav-link" href="/academic-experience/">Academic Experience</a>
+        <a class="main-nav-link" href="/awards/">Awards</a>
       </nav>
       <nav id="sub-nav">
         
@@ -142,11 +142,11 @@
 
     </div>
     <nav id="mobile-nav">
-  
     <a href="/" class="mobile-nav-link">Home</a>
-  
-    <a href="/resume/" class="mobile-nav-link">Resume</a>
-  
+    <a href="/publications/" class="mobile-nav-link">Publications</a>
+    <a href="/research-experience/" class="mobile-nav-link">Research Experience</a>
+    <a href="/academic-experience/" class="mobile-nav-link">Academic Experience</a>
+    <a href="/awards/" class="mobile-nav-link">Awards</a>
 </nav>
     
 


### PR DESCRIPTION
## Summary
- add pages for Publications, Research, Academic Experience, and Awards
- update navigation across all pages
- enhance Home content

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68410e6901a4832e86683fe399a582f6