### PR TITLE
Add inline resume PDF and menu link

### DIFF
--- a/academic-experience/index.html
+++ b/academic-experience/index.html
@@ -22,6 +22,7 @@
             <nav id="main-nav">
               <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
               <a class="main-nav-link" href="/">Home</a>
+                <a class="main-nav-link" href="/resume/">Resume</a>
               <a class="main-nav-link" href="/publications/">Publications</a>
               <a class="main-nav-link" href="/research-experience/">Research Experience</a>
               <a class="main-nav-link" href="/academic-experience/">Academic Experience</a>
@@ -60,6 +61,7 @@
     </div>
     <nav id="mobile-nav">
       <a href="/" class="mobile-nav-link">Home</a>
+        <a href="/resume/" class="mobile-nav-link">Resume</a>
       <a href="/publications/" class="mobile-nav-link">Publications</a>
       <a href="/research-experience/" class="mobile-nav-link">Research Experience</a>
       <a href="/academic-experience/" class="mobile-nav-link">Academic Experience</a>

--- a/awards/index.html
+++ b/awards/index.html
@@ -22,6 +22,7 @@
             <nav id="main-nav">
               <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
               <a class="main-nav-link" href="/">Home</a>
+                <a class="main-nav-link" href="/resume/">Resume</a>
               <a class="main-nav-link" href="/publications/">Publications</a>
               <a class="main-nav-link" href="/research-experience/">Research Experience</a>
               <a class="main-nav-link" href="/academic-experience/">Academic Experience</a>
@@ -61,6 +62,7 @@
     </div>
     <nav id="mobile-nav">
       <a href="/" class="mobile-nav-link">Home</a>
+        <a href="/resume/" class="mobile-nav-link">Resume</a>
       <a href="/publications/" class="mobile-nav-link">Publications</a>
       <a href="/research-experience/" class="mobile-nav-link">Research Experience</a>
       <a href="/academic-experience/" class="mobile-nav-link">Academic Experience</a>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
             <nav id="main-nav">
               <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
               <a class="main-nav-link" href="/">Home</a>
+                <a class="main-nav-link" href="/resume/">Resume</a>
               <a class="main-nav-link" href="/publications/">Publications</a>
               <a class="main-nav-link" href="/research-experience/">Research Experience</a>
               <a class="main-nav-link" href="/academic-experience/">Academic Experience</a>
@@ -43,6 +44,7 @@
                  <p>I am currently enrolled in the Joint Bachelor&rsquo;s Degree Program between Columbia University and the City University of Hong Kong. At Columbia I major in Applied Mathematics and Computer Science (CGPA&nbsp;4.0970/4.00) and at CityU I follow the Artificial Intelligence stream with a minor in Mathematics (CGPA&nbsp;3.98/4.3). My coursework covers advanced programming, natural language processing, deep learning for computer vision, computer science theory, stochastic processes and optimization.</p>
                 <p>My research interests lie in sample&ndash;efficient reinforcement learning and efficient deep learning for edge AI. At Rensselaer Polytechnic Institute I am developing a learning&ndash;history filtering (LHF) mechanism that mitigates suboptimal trajectories in in&ndash;context RL. Earlier at the Shenzhen Research Institute, CityU, I designed a reinforcement&ndash;learning scheduler that coordinates CUDA streams and pruned CNN/Transformer models for real&ndash;time inference on edge GPUs. I also placed within the top&nbsp;15% of the Yale/UNCCH Geophysical Waveform Inversion Kaggle competition by building a physics&ndash;guided ML pipeline.</p>
                 <p>Outside the lab I served as a student helper for web development coursework and led a team in the International Collegiate Programming Contest. Explore the Publications, Research Experience, Academic Experience and Awards pages for more details about my work.</p>
+                  <p><a href="/resume/">View my resume</a></p>
               </div>
             </div>
           </article>
@@ -59,6 +61,7 @@
     </div>
     <nav id="mobile-nav">
       <a href="/" class="mobile-nav-link">Home</a>
+        <a href="/resume/" class="mobile-nav-link">Resume</a>
       <a href="/publications/" class="mobile-nav-link">Publications</a>
       <a href="/research-experience/" class="mobile-nav-link">Research Experience</a>
       <a href="/academic-experience/" class="mobile-nav-link">Academic Experience</a>

--- a/publications/index.html
+++ b/publications/index.html
@@ -22,6 +22,7 @@
             <nav id="main-nav">
               <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
               <a class="main-nav-link" href="/">Home</a>
+                <a class="main-nav-link" href="/resume/">Resume</a>
               <a class="main-nav-link" href="/publications/">Publications</a>
               <a class="main-nav-link" href="/research-experience/">Research Experience</a>
               <a class="main-nav-link" href="/academic-experience/">Academic Experience</a>
@@ -59,6 +60,7 @@
     </div>
     <nav id="mobile-nav">
       <a href="/" class="mobile-nav-link">Home</a>
+        <a href="/resume/" class="mobile-nav-link">Resume</a>
       <a href="/publications/" class="mobile-nav-link">Publications</a>
       <a href="/research-experience/" class="mobile-nav-link">Research Experience</a>
       <a href="/academic-experience/" class="mobile-nav-link">Academic Experience</a>

--- a/research-experience/index.html
+++ b/research-experience/index.html
@@ -22,6 +22,7 @@
             <nav id="main-nav">
               <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
               <a class="main-nav-link" href="/">Home</a>
+                <a class="main-nav-link" href="/resume/">Resume</a>
               <a class="main-nav-link" href="/publications/">Publications</a>
               <a class="main-nav-link" href="/research-experience/">Research Experience</a>
               <a class="main-nav-link" href="/academic-experience/">Academic Experience</a>
@@ -57,6 +58,7 @@
     </div>
     <nav id="mobile-nav">
       <a href="/" class="mobile-nav-link">Home</a>
+        <a href="/resume/" class="mobile-nav-link">Resume</a>
       <a href="/publications/" class="mobile-nav-link">Publications</a>
       <a href="/research-experience/" class="mobile-nav-link">Research Experience</a>
       <a href="/academic-experience/" class="mobile-nav-link">Academic Experience</a>

--- a/resume/index.html
+++ b/resume/index.html
@@ -47,6 +47,7 @@
       <nav id="main-nav">
         <a id="main-nav-toggle" class="nav-icon"><span class="fa fa-bars"></span></a>
         <a class="main-nav-link" href="/">Home</a>
+          <a class="main-nav-link" href="/resume/">Resume</a>
         <a class="main-nav-link" href="/publications/">Publications</a>
         <a class="main-nav-link" href="/research-experience/">Research Experience</a>
         <a class="main-nav-link" href="/academic-experience/">Academic Experience</a>
@@ -75,6 +76,10 @@
   
 
       </header>
+<div class="resume-pdf">
+  <iframe src="/Xinjie_ZHANG_resume_0704.pdf" width="100%" height="1000px"></iframe>
+  <p><a href="/Xinjie_ZHANG_resume_0704.pdf">Download PDF</a></p>
+</div>
     
     <div class="e-content article-entry" itemprop="articleBody">
 <h2>Contact</h2>
@@ -148,6 +153,7 @@
     </div>
     <nav id="mobile-nav">
     <a href="/" class="mobile-nav-link">Home</a>
+<a href="/resume/" class="mobile-nav-link">Resume</a>
     <a href="/publications/" class="mobile-nav-link">Publications</a>
     <a href="/research-experience/" class="mobile-nav-link">Research Experience</a>
     <a href="/academic-experience/" class="mobile-nav-link">Academic Experience</a>


### PR DESCRIPTION
## Summary
- embed the uploaded PDF in `resume/index.html`
- link the Resume page from all navigation menus
- add a direct link to the Resume from the home page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687600e830a4832e9c1397db39416798